### PR TITLE
Adding MonotonicFactory

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,26 @@ let ulid = ULID(ulid: uuid.uuid)
 print(ulid.ulidString) // 01D132CXJVYQ7091KZPZR5WH1X
 ```
 
+### Monotonically Sorted ULIDs
+
+To generate ULIDs that are guaranteed to be monotonically sorted:
+
+```swift
+import ULID
+
+// Create a monotonic factory
+let factory = ULID.MonotonicFactory()
+
+// Generate ULIDs that are guaranteed to sort correctly
+let ulid1 = factory.create()
+let ulid2 = factory.create()
+let ulid3 = factory.create()
+
+// These will always be true
+assert(ulid1 < ulid2)
+assert(ulid2 < ulid3)
+```
+
 ## Installation
 
 ### Swift Package Manager

--- a/Tests/ULIDTests/ULIDTests.swift
+++ b/Tests/ULIDTests/ULIDTests.swift
@@ -299,15 +299,15 @@ struct ULIDTests {
     }
 
     @Test func testMonotonicFactory() {
-        let factory: MonotonicFactory = MonotonicFactory()
-        let timestamp: Date = Date()
+        let factory = ULID.MonotonicFactory()
+        let timestamp = Date()
         
         // Test multiple increments in same millisecond
-        let ulid1: ULID = factory.create(timestamp: timestamp)
-        let ulid2: ULID = factory.create(timestamp: timestamp)
-        let ulid3: ULID = factory.create(timestamp: timestamp)
-        let ulid4: ULID = factory.create(timestamp: timestamp)
-        let ulid5: ULID = factory.create(timestamp: timestamp)
+        let ulid1 = factory.create(timestamp: timestamp)
+        let ulid2 = factory.create(timestamp: timestamp)
+        let ulid3 = factory.create(timestamp: timestamp)
+        let ulid4 = factory.create(timestamp: timestamp)
+        let ulid5 = factory.create(timestamp: timestamp)
         
         // Verify all are strictly increasing
         #expect(ulid1 < ulid2)
@@ -324,7 +324,7 @@ struct ULIDTests {
         
         // Test with future timestamp after sequence
         let newerTimestamp: Date = timestamp.addingTimeInterval(1)
-        let ulid6: ULID = factory.create(timestamp: newerTimestamp)
+        let ulid6 = factory.create(timestamp: newerTimestamp)
         
         #expect(ulid5 < ulid6)
         #expect(String(ulid5.ulidString.prefix(10)) != String(ulid6.ulidString.prefix(10)))

--- a/Tests/ULIDTests/ULIDTests.swift
+++ b/Tests/ULIDTests/ULIDTests.swift
@@ -298,6 +298,39 @@ struct ULIDTests {
         #expect(MemoryLayout<ULID>.size == 16)
     }
 
+    @Test func testMonotonicFactory() {
+        let factory: MonotonicFactory = MonotonicFactory()
+        let timestamp: Date = Date()
+        
+        // Test multiple increments in same millisecond
+        let ulid1: ULID = factory.create(timestamp: timestamp)
+        let ulid2: ULID = factory.create(timestamp: timestamp)
+        let ulid3: ULID = factory.create(timestamp: timestamp)
+        let ulid4: ULID = factory.create(timestamp: timestamp)
+        let ulid5: ULID = factory.create(timestamp: timestamp)
+        
+        // Verify all are strictly increasing
+        #expect(ulid1 < ulid2)
+        #expect(ulid2 < ulid3)
+        #expect(ulid3 < ulid4)
+        #expect(ulid4 < ulid5)
+        
+        // Verify they all have the same timestamp component
+        let timeComponent: String = String(ulid1.ulidString.prefix(10))
+        #expect(timeComponent == String(ulid2.ulidString.prefix(10)))
+        #expect(timeComponent == String(ulid3.ulidString.prefix(10)))
+        #expect(timeComponent == String(ulid4.ulidString.prefix(10)))
+        #expect(timeComponent == String(ulid5.ulidString.prefix(10)))
+        
+        // Test with future timestamp after sequence
+        let newerTimestamp: Date = timestamp.addingTimeInterval(1)
+        let ulid6: ULID = factory.create(timestamp: newerTimestamp)
+        
+        #expect(ulid5 < ulid6)
+        #expect(String(ulid5.ulidString.prefix(10)) != String(ulid6.ulidString.prefix(10)))
+    }
+
+    
 }
 
 extension ULID {


### PR DESCRIPTION
I often find myself wanting to generate ULIDs in quick succession with a guarantee on ordering, so I thought I'd add a monotonic factory (a la [ulidx](https://github.com/perry-mitchell/ulidx/blob/bb685bac8d062bc168d231e97ebffff0dc389963/source/ulid.ts#L267)).  

feel free to accept/reject as you see fit :)  thanks for the awesome package!