### PR TITLE
Fix for android ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,3 +44,14 @@ jobs:
           . "${SWIFTLY_HOME_DIR:-$HOME/.local/share/swiftly}/env.sh"
           swift --version
           swift test
+  linux-android:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: "Test Swift Package on Android"
+        uses: skiptools/swift-android-action@2044b79660f201ccef8cbce62877e4ec5409f9c8 # 2.9.5
+        with:
+          # Ubuntu runners low on space causes the emulator to fail to install
+          free-disk-space: true

--- a/Sources/ULID/ULID.swift
+++ b/Sources/ULID/ULID.swift
@@ -59,16 +59,12 @@ public struct ULID: Hashable, Equatable, Comparable, CustomStringConvertible, Se
                     i += 1
                 }
             }
-            var randomPart: Data = Data()
-            if data.count > randomDataInBytes {
-                randomPart = data.prefix(randomDataInBytes)
-            } else {
-                randomPart = data
-            }
 
-            withUnsafeBytes(of: &randomPart) {
-                for j in 0 ..< 10 {
-                    buffer[i] = $0[j]
+            let randomPart = data.prefix(randomDataInBytes)
+
+            randomPart.withUnsafeBytes { (randomBuffer: UnsafeRawBufferPointer) in
+                for j in 0 ..< randomDataInBytes {
+                    buffer[i] = randomBuffer[j]
                     i += 1
                 }
             }
@@ -77,36 +73,55 @@ public struct ULID: Hashable, Equatable, Comparable, CustomStringConvertible, Se
 
     /// Create a ULID with the given timestamp and random number generator.
     public init<T: RandomNumberGenerator>(timestamp: Date, generator: inout T) {
-        withUnsafeMutableBytes(of: &ulid) { (buffer) in
-            var i = 0
-            var millisec = UInt64(timestamp.timeIntervalSince1970 * 1000.0).bigEndian
-            withUnsafeBytes(of: &millisec) {
-                for j in 2 ..< 8 {
-                    buffer[i] = $0[j]
-                    i += 1
-                }
-            }
-            var random16 = UInt16.random(in: .min ... .max, using: &generator).bigEndian
-            withUnsafeBytes(of: &random16) {
-                for j in 0 ..< 2 {
-                    buffer[i] = $0[j]
-                    i += 1
-                }
-            }
-            var random64 = UInt64.random(in: .min ... .max, using: &generator).bigEndian
-            withUnsafeBytes(of: &random64) {
-                for j in 0 ..< 8 {
-                    buffer[i] = $0[j]
-                    i += 1
-                }
-            }
-        }
+        let millisec = UInt64(timestamp.timeIntervalSince1970 * 1000.0)
+        let r16 = UInt16.random(in: .min ... .max, using: &generator)
+        let r64 = UInt64.random(in: .min ... .max, using: &generator)
+
+        self.ulid = (
+            UInt8((millisec >> 40) & 0xFF),
+            UInt8((millisec >> 32) & 0xFF),
+            UInt8((millisec >> 24) & 0xFF),
+            UInt8((millisec >> 16) & 0xFF),
+            UInt8((millisec >> 8) & 0xFF),
+            UInt8(millisec & 0xFF),
+            UInt8((r16 >> 8) & 0xFF),
+            UInt8(r16 & 0xFF),
+            UInt8((r64 >> 56) & 0xFF),
+            UInt8((r64 >> 48) & 0xFF),
+            UInt8((r64 >> 40) & 0xFF),
+            UInt8((r64 >> 32) & 0xFF),
+            UInt8((r64 >> 24) & 0xFF),
+            UInt8((r64 >> 16) & 0xFF),
+            UInt8((r64 >> 8) & 0xFF),
+            UInt8(r64 & 0xFF)
+        )
     }
 
     /// Create a ULID with the given timestamp.
     public init(timestamp: Date = Date()) {
-        var g = SystemRandomNumberGenerator()
-        self.init(timestamp: timestamp, generator: &g)
+        var generator = SystemRandomNumberGenerator()
+        let millisec = UInt64(timestamp.timeIntervalSince1970 * 1000.0)
+        let r16 = UInt16.random(in: .min ... .max, using: &generator)
+        let r64 = UInt64.random(in: .min ... .max, using: &generator)
+
+        self.ulid = (
+            UInt8((millisec >> 40) & 0xFF),
+            UInt8((millisec >> 32) & 0xFF),
+            UInt8((millisec >> 24) & 0xFF),
+            UInt8((millisec >> 16) & 0xFF),
+            UInt8((millisec >> 8) & 0xFF),
+            UInt8(millisec & 0xFF),
+            UInt8((r16 >> 8) & 0xFF),
+            UInt8(r16 & 0xFF),
+            UInt8((r64 >> 56) & 0xFF),
+            UInt8((r64 >> 48) & 0xFF),
+            UInt8((r64 >> 40) & 0xFF),
+            UInt8((r64 >> 32) & 0xFF),
+            UInt8((r64 >> 24) & 0xFF),
+            UInt8((r64 >> 16) & 0xFF),
+            UInt8((r64 >> 8) & 0xFF),
+            UInt8(r64 & 0xFF)
+        )
     }
 
     /// Returns a raw binary data.


### PR DESCRIPTION
Resolves https://github.com/yaslab/ULID.swift/issues/27

This PR makes ulids be generated correctly when running tests in an android emulator on GitHub CI (presumably x86/64).
Running in an android emulator on an arm macOS worked fine.
The failure can be seen here: https://github.com/amethystsoft/vein/actions/runs/28321125783/job/83903135665

The randomPartData init failed, presumably because withUnsafeBytes(inout…) doesn’t access the data’s inner actual bytes. Not sure why it succeeded on arm before, but it still does and now on android as well.

The other two initializers now use bit shifting, resolving the main test fail reason, and bitwise ands for truncating, which *might* be faster, but at doesn’t touch unsafe apis + is easier to read imo.

The duplication of code instead of calling the rng init from the just-timestamp init resolves a thread sanitizer warning (maybe caused by the generic, I’m not entirely sure). Its possible that it was a false positive, but no warnings is just nicer.

I also added android CI using the skiptools swift-android action. Testing on android sucks to do manually, so thats the way to go. 
It runs on swift 6.3 by default. My android CI currently runs on nightly-main due to some macro related issues in 6.3, but I don’t think these should affect this repo.